### PR TITLE
Add option to notify on fail and keep original notify

### DIFF
--- a/hyprpm/src/main.cpp
+++ b/hyprpm/src/main.cpp
@@ -149,7 +149,7 @@ int                        main(int argc, char** argv, char** envp) {
     } else if (command[0] == "reload") {
         auto ret = g_pPluginManager->ensurePluginsLoadState();
 
-        if (ret != LOADSTATE_OK && (notify || notifyFail)) {
+        if (ret != LOADSTATE_OK && notify) {
             switch (ret) {
                 case LOADSTATE_FAIL:
                 case LOADSTATE_PARTIAL_FAIL: g_pPluginManager->notify(ICON_ERROR, 0, 10000, "[hyprpm] Failed to load plugins"); break;

--- a/hyprpm/src/main.cpp
+++ b/hyprpm/src/main.cpp
@@ -54,7 +54,7 @@ int                        main(int argc, char** argv, char** envp) {
             } else if (ARGS[i] == "--notify" || ARGS[i] == "-n") {
                 notify = true;
             } else if (ARGS[i] == "--notify-fail" || ARGS[i] == "-nn") {
-                notifyFail = true;
+                notifyFail = notify = true;
             } else if (ARGS[i] == "--verbose" || ARGS[i] == "-v") {
                 verbose = true;
             } else if (ARGS[i] == "--no-shallow" || ARGS[i] == "-s") {

--- a/hyprpm/src/main.cpp
+++ b/hyprpm/src/main.cpp
@@ -24,6 +24,7 @@ constexpr std::string_view HELP = R"#(┏ hyprpm, a Hyprland Plugin Manager
 ┣ Flags:
 ┃
 ┣ --notify       | -n    → Send a hyprland notification for important events (e.g. load fail)
+┣ --notify-fail  | -nn   → Send a hyprland notification for fail events
 ┣ --help         | -h    → Show this menu
 ┣ --verbose      | -v    → Enable too much logging
 ┣ --force        | -f    → Force an operation ignoring checks (e.g. update -f)
@@ -43,7 +44,7 @@ int                        main(int argc, char** argv, char** envp) {
     }
 
     std::vector<std::string> command;
-    bool                     notify = false, verbose = false, force = false, noShallow = false;
+    bool                     notify = false, notifyFail = false, verbose = false, force = false, noShallow = false;
 
     for (int i = 1; i < argc; ++i) {
         if (ARGS[i].starts_with("-")) {
@@ -52,6 +53,8 @@ int                        main(int argc, char** argv, char** envp) {
                 return 0;
             } else if (ARGS[i] == "--notify" || ARGS[i] == "-n") {
                 notify = true;
+            } else if (ARGS[i] == "--notify-fail" || ARGS[i] == "-nn") {
+                notifyFail = true;
             } else if (ARGS[i] == "--verbose" || ARGS[i] == "-v") {
                 verbose = true;
             } else if (ARGS[i] == "--no-shallow" || ARGS[i] == "-s") {
@@ -113,7 +116,7 @@ int                        main(int argc, char** argv, char** envp) {
 
             if (ret2 != LOADSTATE_OK)
                 return 1;
-        } else if (notify)
+        } else if (notify || notifyFail)
             g_pPluginManager->notify(ICON_ERROR, 0, 10000, "[hyprpm] Couldn't update headers");
     } else if (command[0] == "enable") {
         if (ARGS.size() < 2) {
@@ -146,7 +149,7 @@ int                        main(int argc, char** argv, char** envp) {
     } else if (command[0] == "reload") {
         auto ret = g_pPluginManager->ensurePluginsLoadState();
 
-        if (ret != LOADSTATE_OK && notify) {
+        if (ret != LOADSTATE_OK && (notify || notifyFail)) {
             switch (ret) {
                 case LOADSTATE_FAIL:
                 case LOADSTATE_PARTIAL_FAIL: g_pPluginManager->notify(ICON_ERROR, 0, 10000, "[hyprpm] Failed to load plugins"); break;
@@ -155,6 +158,9 @@ int                        main(int argc, char** argv, char** envp) {
                     break;
                 default: break;
             }
+        } else if (notify && !notifyFail) {
+            g_pPluginManager->notify(ICON_OK, 0, 4000, "[hyprpm] Loaded plugins");
+        }
     } else if (command[0] == "list") {
         g_pPluginManager->listAllPlugins();
     } else {

--- a/hyprpm/src/main.cpp
+++ b/hyprpm/src/main.cpp
@@ -116,7 +116,7 @@ int                        main(int argc, char** argv, char** envp) {
 
             if (ret2 != LOADSTATE_OK)
                 return 1;
-        } else if (notify || notifyFail)
+        } else if (notify)
             g_pPluginManager->notify(ICON_ERROR, 0, 10000, "[hyprpm] Couldn't update headers");
     } else if (command[0] == "enable") {
         if (ARGS.size() < 2) {

--- a/hyprpm/src/main.cpp
+++ b/hyprpm/src/main.cpp
@@ -23,8 +23,8 @@ constexpr std::string_view HELP = R"#(┏ hyprpm, a Hyprland Plugin Manager
 ┃
 ┣ Flags:
 ┃
-┣ --notify       | -n    → Send a hyprland notification for important events (e.g. load fail)
-┣ --notify-fail  | -nn   → Send a hyprland notification for fail events
+┣ --notify       | -n    → Send a hyprland notification for important events (including both successes and fail events)
+┣ --notify-fail  | -nn   → Send a hyprland notification for fail events only
 ┣ --help         | -h    → Show this menu
 ┣ --verbose      | -v    → Enable too much logging
 ┣ --force        | -f    → Force an operation ignoring checks (e.g. update -f)


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
By adding back original option to notify when successful and a notify-fail option for the need for original PR

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
i just added new option --notify-fail while keeping the --notify in place. So prev command still have the original functionality and we have the option for original PR

#### Is it ready for merging, or does it need work?
It removes the trivial of original PR

